### PR TITLE
🤖 fix(deps): sigstore@^4.1.1 override (GHSA-52v5-jr5w-gjxr)

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,5 +46,8 @@
     "typedoc": "^0.26.5",
     "typescript": "~5.5.2",
     "typescript-eslint": "8.0.0-alpha.38"
+  },
+  "overrides": {
+    "sigstore": "^4.1.1"
   }
 }


### PR DESCRIPTION
🤖 AI-generated, review before forwarding externally. Simple npm overrides patch to close a Dependabot alert; verified pattern from 2026-06-20 undici precedent (heartbeat lessons). No framework bump, no dist rebuild required.

Closes Dependabot alert on transitive sigstore <=4.1.0 → forces ^4.1.1 (patched).

Files changed: `package.json` (added `overrides.sigstore`).

Refs: [github/austenstone-notes#511](https://github.com/github/austenstone-notes/issues/511)